### PR TITLE
quick fix for wallet.dat files that does not have a default key set

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "walletlib"
-version = "0.2.5"
+version = "0.2.6"
 description = "Library for accessing cryptocurrency wallet files"
 authors = ["jim zhou <43537315+jimtje@users.noreply.github.com>"]
 license = "Unlicense"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="walletlib",
-    version="0.2.5",
+    version="0.2.6",
     packages=find_packages(),
     include_package_data=True,
     url="https://github.com/jimtje/walletlib",

--- a/walletlib/__init__.py
+++ b/walletlib/__init__.py
@@ -7,7 +7,7 @@ author: jim zhou jimtje@gmail.com
 
 from .walletdat import Walletdat
 from .protobufwallet import ProtobufWallet
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 __url__ = "https://github.com/jimtje/walletlib"
 

--- a/walletlib/base32.py
+++ b/walletlib/base32.py
@@ -67,10 +67,10 @@ def bech32_decode(bech):
     pos = bech.rfind('1')
     if pos < 1 or pos + 7 > len(bech) or len(bech) > 90:
         return (None, None)
-    if not all(x in CHARSET for x in bech[pos+1:]):
+    if not all(x in CHARSET for x in bech[pos + 1:]):
         return (None, None)
     hrp = bech[:pos]
-    data = [CHARSET.find(x) for x in bech[pos+1:]]
+    data = [CHARSET.find(x) for x in bech[pos + 1:]]
     if not bech32_verify_checksum(hrp, data):
         return (None, None)
     return (hrp, data[:-6])

--- a/walletlib/bitcoinj_compat.py
+++ b/walletlib/bitcoinj_compat.py
@@ -134,7 +134,8 @@ class Key(betterproto.Message):
     # key entry.
     deterministic_seed: bytes = betterproto.bytes_field(8)
     # Encrypted version of the seed
-    encrypted_deterministic_seed: "EncryptedData" = betterproto.message_field(9)
+    encrypted_deterministic_seed: "EncryptedData" = betterproto.message_field(
+        9)
 
 
 @dataclass
@@ -190,7 +191,8 @@ class TransactionConfidence(betterproto.Message):
     # to track them all, just the first. This only makes sense if type = DEAD.
     overriding_transaction: bytes = betterproto.bytes_field(3)
     # If type == BUILDING then this is the depth of the transaction in the
-    # blockchain. Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
+    # blockchain. Zero confirmations: depth = 0, one confirmation: depth = 1
+    # etc.
     depth: int = betterproto.int32_field(4)
     broadcast_by: List["PeerAddress"] = betterproto.message_field(6)
     source: "TransactionConfidenceSource" = betterproto.enum_field(7)
@@ -210,7 +212,8 @@ class Transaction(betterproto.Message):
     lock_time: int = betterproto.uint32_field(4)
     updated_at: int = betterproto.int64_field(5)
     transaction_input: List["TransactionInput"] = betterproto.message_field(6)
-    transaction_output: List["TransactionOutput"] = betterproto.message_field(7)
+    transaction_output: List["TransactionOutput"] = betterproto.message_field(
+        7)
     # A list of blocks in which the transaction has been observed (on any chain).
     # Also, a number used to disambiguate ordering within a block.
     block_hash: List[bytes] = betterproto.bytes_field(8)
@@ -311,7 +314,8 @@ class Wallet(betterproto.Message):
     key_rotation_time: int = betterproto.uint64_field(13)
     tags: List["Tag"] = betterproto.message_field(16)
     # transaction signers added to the wallet
-    transaction_signers: List["TransactionSigner"] = betterproto.message_field(17)
+    transaction_signers: List["TransactionSigner"] = betterproto.message_field(
+        17)
 
 
 @dataclass

--- a/walletlib/coinomi_proto.py
+++ b/walletlib/coinomi_proto.py
@@ -157,7 +157,8 @@ class TransactionConfidence(betterproto.Message):
     # to track them all, just the first. This only makes sense if type = DEAD.
     overriding_transaction: bytes = betterproto.bytes_field(3)
     # If type == BUILDING then this is the depth of the transaction in the
-    # blockchain. Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
+    # blockchain. Zero confirmations: depth = 0, one confirmation: depth = 1
+    # etc.
     depth: int = betterproto.int32_field(4)
     broadcast_by: List["PeerAddress"] = betterproto.message_field(5)
     source: "TransactionConfidenceSource" = betterproto.enum_field(6)
@@ -178,7 +179,8 @@ class Transaction(betterproto.Message):
     lock_time: int = betterproto.uint32_field(4)
     updated_at: int = betterproto.int64_field(5)
     transaction_input: List["TransactionInput"] = betterproto.message_field(6)
-    transaction_output: List["TransactionOutput"] = betterproto.message_field(7)
+    transaction_output: List["TransactionOutput"] = betterproto.message_field(
+        7)
     # A list of blocks in which the transaction has been observed (on any chain).
     # Also, a number used to disambiguate ordering within a block.
     block_hash: List[bytes] = betterproto.bytes_field(8)

--- a/walletlib/crypto.py
+++ b/walletlib/crypto.py
@@ -51,5 +51,3 @@ class Crypter(object):
 
     def decrypt(self, data):
         return AES.new(self.chKey, AES.MODE_CBC, self.chIV).decrypt(data)[0:32]
-
-

--- a/walletlib/exceptions.py
+++ b/walletlib/exceptions.py
@@ -6,14 +6,18 @@ class WalletDatError(Exception):
         super(WalletDatError, self).__init__(message)
         self.file = file
 
+
 class SerializationError(WalletDatError):
     pass
+
 
 class DatabaseError(WalletDatError):
     pass
 
+
 class KeypairError(WalletDatError):
     pass
+
 
 class PasswordError(WalletDatError):
     pass

--- a/walletlib/protobufwallet.py
+++ b/walletlib/protobufwallet.py
@@ -13,6 +13,7 @@ from .crypto import ripemd160_sha256
 from .exceptions import SerializationError, PasswordError
 from hashlib import md5
 
+
 class ProtobufWallet(object):
 
     def __init__(self, data: Any) -> None:
@@ -40,10 +41,9 @@ class ProtobufWallet(object):
         else:
             data = base64.b64decode(data)
 
-
         return cls(data)
 
-    def parse(self, passphrase: Optional[str]=None):
+    def parse(self, passphrase: Optional[str] = None):
         if self.raw_data[:8] == b'Salted__':
             if passphrase is None:
                 raise PasswordError
@@ -60,13 +60,14 @@ class ProtobufWallet(object):
                 iv = newdata[32:32 + AES.block_size]
                 cipher = AES.new(key, AES.MODE_CBC, iv)
                 try:
-                    padded_plain = cipher.decrypt(self.raw_data[AES.block_size:])
+                    padded_plain = cipher.decrypt(
+                        self.raw_data[AES.block_size:])
                     pad_len = padded_plain[-1]
                     if isinstance(pad_len, str):
                         pad_len = ord(pad_len)
                     plain_data = padded_plain[:-pad_len]
                     self.wallet.parse(plain_data)
-                except:
+                except BaseException:
                     raise PasswordError
         else:
             self.wallet.parse(self.raw_data)
@@ -92,21 +93,28 @@ class ProtobufWallet(object):
                 if k.type == 3:
                     mnemonic = k.secret_bytes.decode()
                     deterministic_seed = k.deterministic_seed.hex()
-                    self.mnemonics.append({"mnemonic": mnemonic, "deterministic_seed": deterministic_seed})
+                    self.mnemonics.append(
+                        {"mnemonic": mnemonic, "deterministic_seed": deterministic_seed})
                 elif k.type == 4 or k.type == 1:
-                    creation_timestamp = arrow.get(int(k.creation_timestamp)).isoformat()
+                    creation_timestamp = arrow.get(
+                        int(k.creation_timestamp)).isoformat()
                     keydict = {"creation_timestamp": creation_timestamp}
                     if k.type == 4:
                         deterministic_key = k.deterministic_key.to_dict()
-                        deterministic_key["chainCode"] = base64.b64decode(deterministic_key['chainCode']).hex()
+                        deterministic_key["chainCode"] = base64.b64decode(
+                            deterministic_key['chainCode']).hex()
                         keydict["deterministic_key"] = deterministic_key
                     prefix = bytes([self.default_wifnetwork])
-                    pubkey = base58.b58encode_check(prefix + ripemd160_sha256(k.public_key)).decode()
+                    pubkey = base58.b58encode_check(
+                        prefix + ripemd160_sha256(k.public_key)).decode()
                     keydict["pubkey"] = pubkey
                     if len(k.secret_bytes) > 0:
-                        privkey_prefix = int.to_bytes(self.default_wifnetwork + 128, 1, byteorder='big')
-                        compressed = base58.b58encode_check(privkey_prefix + k.secret_bytes).decode()
-                        uncompressed = base58.b58encode_check(privkey_prefix + k.secret_bytes + b'\x01').decode()
+                        privkey_prefix = int.to_bytes(
+                            self.default_wifnetwork + 128, 1, byteorder='big')
+                        compressed = base58.b58encode_check(
+                            privkey_prefix + k.secret_bytes).decode()
+                        uncompressed = base58.b58encode_check(
+                            privkey_prefix + k.secret_bytes + b'\x01').decode()
                         keydict["compressed_private_key"] = compressed
                         keydict["uncompressed_private_key"] = uncompressed
                     keydict["label"] = k.label
@@ -116,18 +124,23 @@ class ProtobufWallet(object):
                 self.lastblockhash = self.wallet.last_seen_block_hash.hex()
             if hasattr(self.wallet, 'transaction'):
                 for t in self.wallet.transaction:
+                    txjson = t.to_json()
+                    print(txjson)
                     tx = t.to_dict()
                     tx["hash"] = base64.b64decode(tx['hash']).hex()
-                    tx["updatedAt"] = arrow.get(int(tx["updatedAt"])).isoformat()
+                    tx["updatedAt"] = arrow.get(
+                        int(tx["updatedAt"])).isoformat()
                     txinputs = []
                     for txinput in tx['transactionInput']:
                         inputdict = {}
                         if 'transactionOutPointHash' in txinput.keys():
-                            inputdict['transactionOutPointHash'] = base64.b64decode(txinput['transactionOutPointHash']).hex()
+                            inputdict['transactionOutPointHash'] = base64.b64decode(
+                                txinput['transactionOutPointHash']).hex()
                         if 'transactionOutPointIndex' in txinput.keys():
                             inputdict['transactionOutPointIndex'] = txinput['transactionOutPointIndex']
                         if 'scriptBytes' in txinput.keys():
-                            inputdict['scriptBytes'] = base64.b64decode(txinput['scriptBytes']).hex()
+                            inputdict['scriptBytes'] = base64.b64decode(
+                                txinput['scriptBytes']).hex()
                         txinputs.append(inputdict)
                     tx['transactionInput'] = txinputs
                     txoutputs = []
@@ -135,11 +148,12 @@ class ProtobufWallet(object):
                         outputdict = {}
                         if 'spentByTransactionHash' in txoutput.keys():
                             outputdict['spentByTransactionHash'] = base64.b64decode(
-                                    txoutput['spentByTransactionHash']).hex()
+                                txoutput['spentByTransactionHash']).hex()
                         if 'spentByTransactionIndex' in txoutput.keys():
                             outputdict['spentByTransactionIndex'] = txoutput['spentByTransactionIndex']
                         if 'scriptBytes' in txoutput.keys():
-                            outputdict['scriptBytes'] = base64.b64decode(txoutput['scriptBytes']).hex()
+                            outputdict['scriptBytes'] = base64.b64decode(
+                                txoutput['scriptBytes']).hex()
                         if 'value' in txoutput.keys():
                             outputdict['value'] = txoutput['value']
                         txoutputs.append(outputdict)
@@ -156,7 +170,11 @@ class ProtobufWallet(object):
             self.keypairs = self.wallet.to_dict()['key']
 
     def dump_all(self, filepath: Optional[str] = None) -> Dict:
-        output_items = {"keys": self.keypairs, "tx": self.txes, "mnemonics": self.mnemonics, "description": self.description}
+        output_items = {
+            "keys": self.keypairs,
+            "tx": self.txes,
+            "mnemonics": self.mnemonics,
+            "description": self.description}
         if filepath is not None:
             with open(filepath, "a") as ft:
                 ft.write(json.dumps(output_items, sort_keys=True, indent=4))
@@ -172,12 +190,3 @@ class ProtobufWallet(object):
             with open(filepath, "a") as ft:
                 ft.write(json.dumps(output_keys, sort_keys=True, indent=4))
         return output_keys
-
-
-
-
-
-
-
-
-

--- a/walletlib/scripts/dumpwallet.py
+++ b/walletlib/scripts/dumpwallet.py
@@ -12,21 +12,20 @@ import click
 from walletlib import Walletdat, ProtobufWallet
 import json
 
+
 @click.command()
 @click.argument("filename", type=click.Path(exists=True))
 @click.option("-p", "--password", help="Password if any", type=click.STRING)
-@click.option(
-    "-o", "--output", help="File to save to. If not set, results only will be displayed"
-)
+@click.option("-o", "--output",
+              help="File to save to. If not set, results only will be displayed")
 @click.option(
     "-v",
     "--versionprefix",
     type=int,
     help="Force output to use this p2pkh version byte",
 )
-@click.option(
-    "-s", "--secretprefix", type=int, help="Force output to use this WIF version byte"
-)
+@click.option("-s", "--secretprefix", type=int,
+              help="Force output to use this WIF version byte")
 @click.option("--keys", is_flag=True, help="Only dump keys.")
 def main(filename, password, output, versionprefix, secretprefix, keys):
     if filename.endswith(".dat"):
@@ -36,22 +35,31 @@ def main(filename, password, output, versionprefix, secretprefix, keys):
             w.parse(passphrase=str(password))
         else:
             w.parse()
-        click.echo(
-            "Found {} keypairs and {} transactions".format(len(w.keypairs), len(w.txes))
-        )
+        click.echo("Found {} keypairs and {} transactions".format(
+            len(w.keypairs), len(w.txes)))
         click.echo("Default version byte: {}".format(w.default_wifnetwork))
         if keys:
             if not output:
-                d = w.dump_keys(version=versionprefix, privkey_prefix_override=secretprefix)
+                d = w.dump_keys(
+                    version=versionprefix,
+                    privkey_prefix_override=secretprefix)
                 click.echo(json.dumps(d, sort_keys=True, indent=4))
             else:
-                w.dump_keys(output, version=versionprefix, privkey_prefix_override=secretprefix)
+                w.dump_keys(
+                    output,
+                    version=versionprefix,
+                    privkey_prefix_override=secretprefix)
         else:
             if not output:
-                d = w.dump_all(version=versionprefix, privkey_prefix_override=secretprefix)
+                d = w.dump_all(
+                    version=versionprefix,
+                    privkey_prefix_override=secretprefix)
                 click.echo(json.dumps(d, sort_keys=True, indent=4))
             else:
-                w.dump_all(output, version=versionprefix, privkey_prefix_override=secretprefix)
+                w.dump_all(
+                    output,
+                    version=versionprefix,
+                    privkey_prefix_override=secretprefix)
         click.echo("Done")
     else:
         try:
@@ -61,7 +69,8 @@ def main(filename, password, output, versionprefix, secretprefix, keys):
                 w.parse(passphrase=str(password))
             else:
                 w.parse()
-            click.echo("Found {} keypairs and {} transactions".format(len(w.keypairs), len(w.txes)))
+            click.echo("Found {} keypairs and {} transactions".format(
+                len(w.keypairs), len(w.txes)))
             click.echo("Default version byte: {}".format(w.default_wifnetwork))
             if keys:
                 if not output:
@@ -76,6 +85,5 @@ def main(filename, password, output, versionprefix, secretprefix, keys):
                 else:
                     w.dump_all(output)
             click.echo("Done")
-        except:
+        except BaseException:
             click.echo("Error, cannot read wallet file")
-

--- a/walletlib/utils.py
+++ b/walletlib/utils.py
@@ -27,7 +27,7 @@ class BCDataStream(object):
 
     def read_bytes(self, length):
         try:
-            result = self.input[self.read_cursor : self.read_cursor + length]
+            result = self.input[self.read_cursor: self.read_cursor + length]
             self.read_cursor += length
             return result
         except IndexError:
@@ -101,7 +101,7 @@ def parse_CAddress(vds):
         d["pchReserved"] = vds.read_bytes(12)
         d["ip"] = socket.inet_ntoa(vds.read_bytes(4))
         d["port"] = vds.read_uint16()
-    except:
+    except BaseException:
         pass
     return d
 

--- a/walletlib/wallet_segwit.py
+++ b/walletlib/wallet_segwit.py
@@ -141,7 +141,8 @@ class Key(betterproto.Message):
     # key entry.
     deterministic_seed: bytes = betterproto.bytes_field(8)
     # Encrypted version of the seed
-    encrypted_deterministic_seed: "EncryptedData" = betterproto.message_field(9)
+    encrypted_deterministic_seed: "EncryptedData" = betterproto.message_field(
+        9)
     # The path to the root. Only applicable to a DETERMINISTIC_MNEMONIC key
     # entry.
     account_path: List[int] = betterproto.uint32_field(10)
@@ -209,7 +210,8 @@ class TransactionConfidence(betterproto.Message):
     # to track them all, just the first. This only makes sense if type = DEAD.
     overriding_transaction: bytes = betterproto.bytes_field(3)
     # If type == BUILDING then this is the depth of the transaction in the
-    # blockchain. Zero confirmations: depth = 0, one confirmation: depth = 1 etc.
+    # blockchain. Zero confirmations: depth = 0, one confirmation: depth = 1
+    # etc.
     depth: int = betterproto.int32_field(4)
     broadcast_by: List["PeerAddress"] = betterproto.message_field(6)
     # Millis since epoch the transaction was last announced to us.
@@ -231,7 +233,8 @@ class Transaction(betterproto.Message):
     lock_time: int = betterproto.uint32_field(4)
     updated_at: int = betterproto.int64_field(5)
     transaction_input: List["TransactionInput"] = betterproto.message_field(6)
-    transaction_output: List["TransactionOutput"] = betterproto.message_field(7)
+    transaction_output: List["TransactionOutput"] = betterproto.message_field(
+        7)
     # A list of blocks in which the transaction has been observed (on any chain).
     # Also, a number used to disambiguate ordering within a block.
     block_hash: List[bytes] = betterproto.bytes_field(8)


### PR DESCRIPTION
fix in cases when the wallet.dat does not have a default key, enabling the dumping of contents regardless